### PR TITLE
Layout - 헤더, 푸터 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "postcss": "^8.4.23",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.8.0",
     "react-router-dom": "^6.11.1",
     "tailwindcss": "^3.3.2"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,14 @@
-import Header from './components/layout/Header';
-import Footer from './components/layout/Footer';
+import Header from './components/layout/Header.jsx';
+import Footer from './components/layout/Footer.jsx';
 import { Outlet } from 'react-router-dom';
 
 function App() {
   return (
     <>
       <Header />
-      <Outlet />
+      <main>
+        <Outlet />
+      </main>
       <Footer />
     </>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,15 @@
+import Header from './components/layout/Header';
+import Footer from './components/layout/Footer';
+import { Outlet } from 'react-router-dom';
+
+function App() {
+  return (
+    <>
+      <Header />
+      <Outlet />
+      <Footer />
+    </>
+  );
+}
+
+export default App;

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Footer() {
+  return (
+    <footer className='p-3 text-center text-sm text-gray-400 border-t border-solid border-gray-200'>
+      <span>개인정보 처리방침</span> | <span>이용 약관</span>
+      <p>All rights reserved @ Codestates</p>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Header() {
+  return <div>Header</div>;
+}
+
+export default Header;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,7 +1,18 @@
-import React from 'react';
+import { Link } from 'react-router-dom';
+import { RxHamburgerMenu } from 'react-icons/rx';
 
 function Header() {
-  return <div>Header</div>;
+  return (
+    <header className='flex justify-between px-14 py-4 shadow-lg items-center'>
+      <Link to='/'>
+        <section className='flex gap-2 items-center'>
+          <img src='../public/codestates.png' alt='코드스테이츠 로고' width='42' />
+          <h1 className='text-2xl font-bold'>COZ Shopping</h1>
+        </section>
+      </Link>
+      <RxHamburgerMenu size={26} />
+    </header>
+  );
 }
 
 export default Header;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,16 +1,35 @@
+import { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { RxHamburgerMenu } from 'react-icons/rx';
+import Dropdown from '../ui/Dropdown.jsx';
 
 function Header() {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef(null);
+
+  const handleOutsideClick = (e) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+      setIsOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.body.addEventListener('click', handleOutsideClick);
+    return () => document.body.removeEventListener('click', handleOutsideClick);
+  }, []);
+
   return (
     <header className='flex justify-between px-14 py-4 shadow-lg items-center'>
       <Link to='/'>
-        <section className='flex gap-2 items-center'>
+        <section className='flex gap-2 items-center cursor-pointer'>
           <img src='../public/codestates.png' alt='코드스테이츠 로고' width='42' />
           <h1 className='text-2xl font-bold'>COZ Shopping</h1>
         </section>
       </Link>
-      <RxHamburgerMenu size={26} />
+      <nav className='cursor-pointer' ref={dropdownRef}>
+        <RxHamburgerMenu size={26} onClick={() => setIsOpen(!isOpen)} />
+        {isOpen && <Dropdown setIsOpen={setIsOpen} />}
+      </nav>
     </header>
   );
 }

--- a/src/components/ui/Dropdown.jsx
+++ b/src/components/ui/Dropdown.jsx
@@ -1,0 +1,33 @@
+import { HiOutlineGift, HiOutlineStar } from 'react-icons/hi';
+import { useNavigate } from 'react-router-dom';
+
+function Dropdown({ setIsOpen }) {
+  const navigate = useNavigate();
+
+  const handleLinkClick = (url) => {
+    setIsOpen(false);
+    navigate(url);
+  };
+
+  const dropdownStyle = {
+    ul: 'bg-white shadow-[0_2px_10px_1px_rgba(0,0,0,0.1)] rounded-lg absolute top-14 right-6',
+    hi: 'px-6 py-4 text-center cursor-default',
+    li: 'flex gap-2 px-6 py-4 items-center border-t border-solid border-slate-200 hover:bg-slate-100',
+  };
+
+  return (
+    <ul className={dropdownStyle.ul}>
+      <li className={dropdownStyle.hi}>회원님, 안녕하세요!</li>
+      <li className={dropdownStyle.li} onClick={() => handleLinkClick('/products/list')}>
+        <HiOutlineGift size={23} />
+        상품리스트 페이지
+      </li>
+      <li className={dropdownStyle.li} onClick={() => handleLinkClick('/bookmark')}>
+        <HiOutlineStar size={23} />
+        북마크 페이지
+      </li>
+    </ul>
+  );
+}
+
+export default Dropdown;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,23 +1,30 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.css';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import MainPage from './pages/MainPage.jsx';
 import ProductListPage from './pages/ProductListPage.jsx';
 import BookmarkPage from './pages/BookmarkPage.jsx';
+import App from './App.jsx';
+import './index.css';
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <MainPage />,
-  },
-  {
-    path: '/products/list',
-    element: <ProductListPage />,
-  },
-  {
-    path: '/bookmark',
-    element: <BookmarkPage />,
+    element: <App />,
+    children: [
+      {
+        index: true,
+        element: <MainPage />,
+      },
+      {
+        path: '/products/list',
+        element: <ProductListPage />,
+      },
+      {
+        path: '/bookmark',
+        element: <BookmarkPage />,
+      },
+    ],
   },
 ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,6 +1828,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-icons@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.8.0.tgz#621e900caa23b912f737e41be57f27f6b2bff445"
+  integrity sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Desc

- 모든 페이지에서 헤더, 푸터 렌더링
   - react-router-dom의 Outlet 컴포넌트 사용 
- 헤더 left section 클릭시 메인페이지로 이동
- 헤더 rignt section의 햄버거 버튼 및 드롭다운 메뉴 아이콘에 react-icons 라이브러리 사용
- 햄버거 버튼 클릭시 드롭다운 열림, 햄버거 버튼 재클릭 혹은 외부 영역 클릭시 드롭다운 닫힘
   - useRef와 useEffect를 이용해 document.body의 클릭 이벤트 감지 
- 드롭다운 내부의 상품리스트 페이지, 북마크 페이지 클릭시 각각 페이지로 이동되며 드롭다운 닫힘