### PR TITLE
무한 스크롤 구현

### DIFF
--- a/src/components/view/ProductList.jsx
+++ b/src/components/view/ProductList.jsx
@@ -1,17 +1,28 @@
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import useInfiniteScroll from '../../hooks/useInfiniteScroll';
 import Card from './Card';
 
 function ProductList() {
   const [searchParams] = useSearchParams();
   const sort = searchParams.get('sort');
+  const isAll = !sort || sort === 'all';
   const products = useSelector((state) => state.products);
-  const [filteredProducts, setFilteredProducts] = useState(products);
+  const [filteredProducts, setFilteredProducts] = useState([]);
+  const scrollRef = useRef(null);
+
+  useInfiniteScroll(scrollRef, () => {
+    setFilteredProducts((prev) => {
+      let currentLength = prev.length + 25;
+      if (products.length <= currentLength) currentLength = products.length;
+      return [...prev, ...products.slice(prev.length, currentLength)];
+    });
+  });
 
   useEffect(() => {
-    if (!sort || sort === 'all') {
-      setFilteredProducts(products);
+    if (isAll) {
+      setFilteredProducts(products.slice(0, 30));
       return;
     }
     const newProducts = products.filter((product) => product.type.toLowerCase() === sort);
@@ -23,6 +34,7 @@ function ProductList() {
       {filteredProducts.map((product) => (
         <Card key={product.id} product={product} />
       ))}
+      {isAll && <span ref={scrollRef}></span>}
     </div>
   );
 }

--- a/src/hooks/useInfiniteScroll.jsx
+++ b/src/hooks/useInfiniteScroll.jsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+function useInfiniteScroll(ref, callback) {
+  const options = { threshold: 0 };
+  const observer = new IntersectionObserver(([entry]) => {
+    if (entry.isIntersecting) callback();
+  }, options);
+
+  useEffect(() => {
+    if (ref.current) observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref.current]);
+}
+
+export default useInfiniteScroll;


### PR DESCRIPTION
## Desc

- intersection observer API를 이용한 무한스크롤 구현
- 상품리스트 페이지, 북마크 페이지에서 상품 타입이 '전체'일 때 적용
- 상품리스트 페이지에서는 25개, 북마크 페이지에서는 15개씩 가져옴
- 무한스크롤 로직을 커스텀 훅으로 만들어 재사용성을 높임
- 메인페이지에서 각 페이지로 최초 진입시, 데이터가 페인팅되면서 바닥이 먼저 보여져 최초 2회 데이터 불러와지는 현상이 있음 