### PR TITLE
리팩토링 - 무한스크롤

### DIFF
--- a/src/components/view/BookmarkList.jsx
+++ b/src/components/view/BookmarkList.jsx
@@ -10,7 +10,7 @@ function BookmarkList() {
   const sort = searchParams.get('sort');
   const isAll = !sort || sort === 'all';
   const { bookmarks } = useSelector((state) => state.products);
-  const [filteredBookmarks, setFilteredBookmarks] = useState([]);
+  const [filteredBookmarks, setFilteredBookmarks] = useState(bookmarks.slice(0, 15));
   const scrollRef = useRef(null);
 
   useInfiniteScroll(scrollRef, () => {

--- a/src/components/view/ProductList.jsx
+++ b/src/components/view/ProductList.jsx
@@ -9,7 +9,7 @@ function ProductList() {
   const sort = searchParams.get('sort');
   const isAll = !sort || sort === 'all';
   const { products } = useSelector((state) => state.products);
-  const [filteredProducts, setFilteredProducts] = useState([]);
+  const [filteredProducts, setFilteredProducts] = useState(products.slice(0, 30));
   const scrollRef = useRef(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Desc

- 최초 페이지 진입시 무한스크롤이 2회 실행되는 버그 해결
   - 렌더링되는 리스트의 초기값이 빈 배열이어서 최초 진입시 바닥 html 요소가 보이게 되어 생겼던 문제
   - 필터된 배열을 관리하는 상태의 초기값을 상품페이지 30개, 북마크페이지 15개로 설정하여 해결